### PR TITLE
FIX: Chained methods using mox should return the next object in the chain

### DIFF
--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -482,9 +482,9 @@ Mock chained methods
     >>> my_mock = mox.MockObject(some_object)
     >>> my_mock2 = mox.MockAnything()
     >>> my_mock3 = mox.MockAnything()
-    >>> my_mock.method1().AndReturn(my_mock)                     #doctest: +SKIP
+    >>> my_mock.method1().AndReturn(my_mock2)                     #doctest: +SKIP
     <MockAnything instance>
-    >>> my_mock2.method2().AndReturn(my_mock2)
+    >>> my_mock2.method2().AndReturn(my_mock3)
     <MockAnything instance>
     >>> my_mock3.method3(arg1, arg2).AndReturn('some_value')
     'some_value'


### PR DESCRIPTION
I'm not entirely sure about this one as I have no significant experience with mox, but logical reasoning suggests, that each chained call should return the next object in the chain to step forward.
